### PR TITLE
Fix a client can cheat with using the wrong preimage for a request

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,11 +18,14 @@ vNext
         - Method `Get(url string) (*http.Response, error)` - A convenience method for the `Do(...)` method, also an equivalent to the same Go `http.Client` method (regarding its usage)
     - Example client in `examples/client/main.go`
 - Added: Method `Pay(invoice string) (string, error)` for `ln.LNDclient` - Implements the new `pay.LNclient` interface, so that the `LNDclient` can be used as parameter in the `pay.NewClient(...)` function. (Issue [#20](https://github.com/philippgille/ln-paywall/issues/20))
-- Fixed: Some info logs were logged to stderr instead of stdout
+- Fixed: A client could cheat in multiple ways, for example use a preimage for a request to endpoint A while the invoice was for endpoint B, with B being cheaper than A. Or if the LN node is used for other purposes as well, a client could send any preimage that might be for a totally different invoice, not related to the API at all. (Issue [#16](https://github.com/philippgille/ln-paywall/issues/16))
+- Fixed: Some info logs were logged to `stderr` instead of `stdout`
 
 ### Breaking changes
 
 - Changed: The preimage in the `X-Preimage` header must now be hex encoded instead of Base64 encoded. The hex encoded representation is the typical representation, as used by "lncli listpayments", Eclair on Android and bolt11 payment request decoders like [https://lndecode.com](https://lndecode.com). Base64 was used previously because "lncli listinvoices" uses that encoding. (Issue [#8](https://github.com/philippgille/ln-paywall/issues/8))
+- Changed: Interface `wall.StorageClient` and thus all its implementations in the `storage` package were significantly changed. The methods are now completely independent of any ln-paywall specifics, with `Set(...)` and `Get(...)` just setting and retrieving any arbitrary `interface{}` to/from the storage. (Required for issue [#16](https://github.com/philippgille/ln-paywall/issues/16).)
+- Changed: The method `GenerateInvoice(int64, string) (string, error)` in the interface `wall.LNclient` was changed to return a `ln.Invoice` object, which makes it much easier to access the invoice ID (a.k.a. preimage hash, a.k.a. payment hash), instead of having to decode the invoice. (Useful for issue [#16](https://github.com/philippgille/ln-paywall/issues/16), in which the invoice ID is required as key in the storage.)
 
 v0.4.0 (2018-09-03)
 -------------------

--- a/ln/ln.go
+++ b/ln/ln.go
@@ -10,6 +10,19 @@ import (
 // stdOutLogger logs to stdout, while the default log package loggers log to stderr.
 var stdOutLogger = log.New(os.Stdout, "", log.LstdFlags)
 
+// Invoice is a Lightning Network invoice and contains the typical invoice string and the payment hash.
+type Invoice struct {
+	// The actual invoice string required by the payer in Bech32 encoding,
+	// see https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md
+	PaymentRequest string
+	// A.k.a. preimage hash.
+	// Could be extracted from the PaymentRequest, but that would require additional
+	// dependencies during build time and additional computation during runtime,
+	// while all Lightning Node implementation clients already return the value directly
+	// when generating a new invoice.
+	PaymentHash string
+}
+
 // HashPreimage turns a hex encoded preimage into a hex encoded preimage hash.
 // It's the same format that's being used by "lncli listpayments", Eclair on Android and bolt11 payment request decoders like https://lndecode.com.
 // Only "lncli listinvoices" uses Base64.

--- a/ln/lnd.go
+++ b/ln/lnd.go
@@ -22,7 +22,9 @@ type LNDclient struct {
 }
 
 // GenerateInvoice generates an invoice with the given price and memo.
-func (c LNDclient) GenerateInvoice(amount int64, memo string) (string, error) {
+func (c LNDclient) GenerateInvoice(amount int64, memo string) (Invoice, error) {
+	result := Invoice{}
+
 	// Create the request and send it
 	invoice := lnrpc.Invoice{
 		Memo:  memo,
@@ -31,10 +33,12 @@ func (c LNDclient) GenerateInvoice(amount int64, memo string) (string, error) {
 	stdOutLogger.Println("Creating invoice for a new API request")
 	res, err := c.lndClient.AddInvoice(c.ctx, &invoice)
 	if err != nil {
-		return "", err
+		return result, err
 	}
 
-	return res.GetPaymentRequest(), nil
+	result.PaymentHash = string(res.RHash)
+	result.PaymentRequest = res.PaymentRequest
+	return result, nil
 }
 
 // CheckInvoice takes a hex encoded preimage and checks if the corresponding invoice was settled.

--- a/storage/bolt_test.go
+++ b/storage/bolt_test.go
@@ -60,9 +60,17 @@ func TestBoltClientConcurrent(t *testing.T) {
 	waitGroup.Wait()
 
 	// Now make sure that all values are in the storage
-	expected := true
+	expected := foo{}
 	for i := 0; i < goroutineCount; i++ {
-		actual, _ := boltClient.WasUsed(strconv.Itoa(i))
+		actualPtr := new(foo)
+		found, err := boltClient.Get(strconv.Itoa(i), actualPtr)
+		if err != nil {
+			t.Errorf("An error occurred during the test: %v", err)
+		}
+		if !found {
+			t.Errorf("No value was found, but should have been")
+		}
+		actual := *actualPtr
 		if actual != expected {
 			t.Errorf("Expected: %v, but was: %v", expected, actual)
 		}

--- a/storage/map.go
+++ b/storage/map.go
@@ -9,17 +9,25 @@ type GoMap struct {
 	m *sync.Map
 }
 
-// WasUsed checks if the preimage was used for a previous payment already.
-func (m GoMap) WasUsed(preimage string) (bool, error) {
-	// We don't need the value. "ok" contains whether a value was found.
-	_, ok := m.m.Load(preimage)
-	return ok, nil
+// Set stores the given object for the given key.
+func (m GoMap) Set(k string, v interface{}) error {
+	data, err := toJSON(v)
+	if err != nil {
+		return err
+	}
+	m.m.Store(k, data)
+	return nil
 }
 
-// SetUsed stores the information that a preimage has been used for a payment.
-func (m GoMap) SetUsed(preimage string) error {
-	m.m.Store(preimage, true)
-	return nil
+// Get retrieves the stored object for the given key and populates the fields of the object that v points to
+// with the values of the retrieved object's values.
+func (m GoMap) Get(k string, v interface{}) (bool, error) {
+	data, found := m.m.Load(k)
+	if !found {
+		return false, nil
+	}
+
+	return true, fromJSON(data.([]byte), v)
 }
 
 // NewGoMap creates a new GoMap.

--- a/storage/map_test.go
+++ b/storage/map_test.go
@@ -44,9 +44,17 @@ func TestGoMapConcurrent(t *testing.T) {
 	waitGroup.Wait()
 
 	// Now make sure that all values are in the storage
-	expected := true
+	expected := foo{}
 	for i := 0; i < goroutineCount; i++ {
-		actual, _ := goMap.WasUsed(strconv.Itoa(i))
+		actualPtr := new(foo)
+		found, err := goMap.Get(strconv.Itoa(i), actualPtr)
+		if err != nil {
+			t.Errorf("An error occurred during the test: %v", err)
+		}
+		if !found {
+			t.Errorf("No value was found, but should have been")
+		}
+		actual := *actualPtr
 		if actual != expected {
 			t.Errorf("Expected: %v, but was: %v", expected, actual)
 		}

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -68,9 +68,17 @@ func TestRedisClientConcurrent(t *testing.T) {
 	waitGroup.Wait()
 
 	// Now make sure that all values are in the storage
-	expected := true
+	expected := foo{}
 	for i := 0; i < goroutineCount; i++ {
-		actual, _ := redisClient.WasUsed(strconv.Itoa(i))
+		actualPtr := new(foo)
+		found, err := redisClient.Get(strconv.Itoa(i), actualPtr)
+		if err != nil {
+			t.Errorf("An error occurred during the test: %v", err)
+		}
+		if !found {
+			t.Errorf("No value was found, but should have been")
+		}
+		actual := *actualPtr
 		if actual != expected {
 			t.Errorf("Expected: %v, but was: %v", expected, actual)
 		}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,0 +1,13 @@
+package storage
+
+import (
+	"encoding/json"
+)
+
+func toJSON(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func fromJSON(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
+}

--- a/wall/gin.go
+++ b/wall/gin.go
@@ -1,6 +1,7 @@
 package wall
 
 import (
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net/http"
@@ -24,16 +25,24 @@ func NewGinMiddleware(invoiceOptions InvoiceOptions, lnClient LNclient, storageC
 				http.Error(ctx.Writer, errorMsg, http.StatusInternalServerError)
 				ctx.Abort()
 			} else {
+				// Cache the invoice metadata
+				invoiceID := hex.EncodeToString([]byte(invoice.PaymentHash))
+				metadata := invoiceMetaData{
+					Method: ctx.Request.Method,
+					Path:   ctx.Request.URL.Path,
+				}
+				storageClient.Set(invoiceID, metadata)
+
 				stdOutLogger.Printf("Sending invoice in response: %v", invoice)
 				ctx.Header("Content-Type", "application/vnd.lightning.bolt11")
 				ctx.Status(http.StatusPaymentRequired)
 				// The actual invoice goes into the body
-				ctx.Writer.Write([]byte(invoice))
+				ctx.Writer.Write([]byte(invoice.PaymentRequest))
 				ctx.Abort()
 			}
 		} else {
 			// Check if the provided preimage belongs to a settled API payment invoice and that it wasn't already used. Also store used preimages.
-			invalidPreimageMsg, err := handlePreimage(preimageHex, storageClient, lnClient)
+			invalidPreimageMsg, err := handlePreimage(ctx.Request, storageClient, lnClient)
 			if err != nil {
 				errorMsg := fmt.Sprintf("An error occurred during checking the preimage: %+v", err)
 				log.Printf("%v\n", errorMsg)

--- a/wall/middleware.go
+++ b/wall/middleware.go
@@ -3,9 +3,12 @@ package wall
 import (
 	"encoding/hex"
 	"log"
+	"net/http"
 	"os"
 	"reflect"
 	"strings"
+
+	"github.com/philippgille/ln-paywall/ln"
 )
 
 // stdOutLogger logs to stdout, while the default log package loggers log to stderr.
@@ -30,42 +33,87 @@ var DefaultInvoiceOptions = InvoiceOptions{
 }
 
 // StorageClient is an abstraction for different storage client implementations.
-// A storage client must only be able to check if a preimage was already used for a payment bofore
-// and to store a preimage that was used before.
+// A storage client must be able to store and retrieve invoiceMetaData objects.
 type StorageClient interface {
-	WasUsed(string) (bool, error)
-	SetUsed(string) error
+	// Set stores the given invoiceMetaData for the given invoice ID.
+	Set(string, interface{}) error
+	// Get retrieves the invoiceMetaData for the given invoice ID
+	// and populates the fields of the object that the passed pointer
+	// points to with the values of the retrieved object's values.
+	// If no object is found it returns (false, nil).
+	Get(string, interface{}) (bool, error)
 }
 
 // LNclient is an abstraction of a client that connects to a Lightning Network node implementation (like lnd, c-lightning and eclair)
 // and provides the methods required by the paywall.
 type LNclient interface {
-	GenerateInvoice(int64, string) (string, error)
+	GenerateInvoice(int64, string) (ln.Invoice, error)
 	CheckInvoice(string) (bool, error)
 }
 
-// handlePreimage does four things:
-// 1) Checks if the preimage was already used as a payment proof before.
-// 2) Checks if the preimage corresponds to an existing invoice on the connected LN node.
-// 3) Checks if the corresponding invoice was settled.
-// 4) Store the preimage to the storage for future checks.
+// invoiceMetaData is data that's required to prevent clients from cheating
+// (e.g. have multiple requests executed while having paid only once,
+// or requesting an invoice for a cheap endpoint and using the payment proof for an expensive one).
+// The type itself is not exported, but the fields have to be (for (un-)marshaling).
+type invoiceMetaData struct {
+	Method string
+	Path   string
+	Used   bool
+}
+
+// handlePreimage does the following:
+// 1) Validate the preimage format (encoding, length)
+// 2) Check if the invoice ID exists in the storage
+// 3) Check if the current HTTP verb and URL path match the ones used for creating the invoice
+// 4) Check if the invoice ID was already used in a previous request
+// 5) Check if the invoice was settled
+// 6) Mark the invoice ID as used, so it can't be used in future requests
+// Note: The invoice ID (a.k.a. payment hash, a.k.a. preimage hash) can be calculated from the preimage.
+//
 // Returns a string and an error.
-// The string contains detailed info about the result in case the preimage is invalid.
-// The error is only non-nil if an error occurs during the check (like the LN node can't be reached).
+// The string contains detailed info about the result in case the preimage is invalid
+// (bad encoding, HTTP verb doesn't match, already used etc., generally a client-side error).
+// The error is only non-nil if a server-side error occurred during the check (like the LN node can't be reached).
 // The preimage is only valid if the string is empty and the error is nil.
-func handlePreimage(preimageHex string, storageClient StorageClient, lnClient LNclient) (string, error) {
-	// Check if it was already used before
-	wasUsed, err := storageClient.WasUsed(preimageHex)
+func handlePreimage(req *http.Request, storageClient StorageClient, lnClient LNclient) (string, error) {
+	// 1) Validate the preimage format (encoding, length)
+	preimage := req.Header.Get("X-Preimage")
+	errString := validatePreimageFormat(preimage)
+	if errString != "" {
+		return errString, nil
+	}
+
+	// Calculate invoice ID from preimage.
+	// Ignore error because we already validated the preimage format.
+	invoiceID, _ := ln.HashPreimage(preimage)
+
+	// Retrieve invoice metadata from storage
+	metaData := new(invoiceMetaData)
+	found, err := storageClient.Get(invoiceID, metaData)
 	if err != nil {
 		return "", err
 	}
-	if wasUsed {
-		// Key was found, which means the payment was already used for an API call.
-		return "The provided preimage was already used in a previous request", nil
+
+	// Execute all checks that we can do locally.
+
+	// 2. Check if the invoice ID exists in the storage
+	if !found {
+		return "You seem to have sent an invalid preimage or one that doesn't correspond to an invoice that was issued for an initial request", nil
+	}
+	// 3) Check if the current HTTP verb and URL path match the ones used for creating the invoice
+	if req.Method != metaData.Method {
+		return "Your invoice was created for a " + metaData.Method + " request, but you're sending a " + req.Method + " request", nil
+	}
+	if req.URL.Path != metaData.Path {
+		return "Your invoice was created for the path \"" + metaData.Path + "\", but you're sending a request to \"" + req.URL.Path + "\"", nil
+	}
+	// 4) Check if the invoice ID was already used in a previous request
+	if metaData.Used {
+		return "You already sent a request with the same preimage. You have to pay a new invoice for and include the corresponding preimage in each request.", nil
 	}
 
-	// Check if a corresponding invoice exists and is settled
-	settled, err := lnClient.CheckInvoice(preimageHex)
+	// 5) Check if the invoice was settled
+	settled, err := lnClient.CheckInvoice(preimage)
 	if err != nil {
 		// Returning a non-nil error leads to an "internal server error", but in some cases it's a "bad request".
 		// Handle those cases here.
@@ -83,13 +131,26 @@ func handlePreimage(preimageHex string, storageClient StorageClient, lnClient LN
 		return "You somehow obtained the preimage of the invoice, but the invoice is not settled yet", nil
 	}
 
-	// Key not found, so it wasn't used before.
-	// Insert key for future checks.
-	err = storageClient.SetUsed(preimageHex)
+	// 6) Mark the invoice ID as used, so it can't be used in future requests
+	metaData.Used = true
+	err = storageClient.Set(invoiceID, *metaData)
 	if err != nil {
 		return "", err
 	}
+
 	return "", nil
+}
+
+func validatePreimageFormat(preimageHex string) string {
+	if len(preimageHex) != 64 {
+		return "The provided preimage isn't properly formatted"
+	}
+	_, err := hex.DecodeString(preimageHex)
+	if err != nil {
+		// Either err == hex.ErrLength or err == hex.InvalidByteError.
+		return "The provided preimage isn't properly hex encoded"
+	}
+	return ""
 }
 
 func assignDefaultValues(invoiceOptions InvoiceOptions) InvoiceOptions {


### PR DESCRIPTION
- Previously a client just had to send any preimage that corresponds to a settled invoice in the LN node,
without the invoice having to originate from the middleware, or from the same endpoint as used in
the current request. So he could pay cheap invoices and use expensive endpoints for example.
- The fix required storing metadata in the DB, e.g. the HTTP method and URL path,
while being backward compatible and not send those data encrypted as token in the first response,
requiring the same token and decrypting and using the values during the second request
- Both modes are interesting and have their pros and cons, so evaluate supporting both in the future
- Storing the metadata required changing the wall.StorageClient interface and its implementations
in the storage package

Closes #16