### PR TITLE
Refactor middlewares

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 vNext
 -----
 
+- Fixed: When using the Echo middleware the invoice response status code was 200 OK instead of 402 Payment Required (issue [#30](https://github.com/philippgille/ln-paywall/issues/30))
+- Fixed: When using the Echo middleware error responses (including the invoice) were wrapped in JSON instead of just text (issue [#30](https://github.com/philippgille/ln-paywall/issues/30))
+
 v0.5.1 (2018-10-02)
 -------------------
 

--- a/wall/echo.go
+++ b/wall/echo.go
@@ -36,19 +36,19 @@ func (fa echoAbstraction) getPreimageFromHeader() string {
 	return fa.ctx.Request().Header.Get("x-preimage")
 }
 
-func (fa echoAbstraction) respondWithError(err error, errorMsg string, statusCode int) error {
-	return fa.ctx.String(statusCode, errorMsg)
+func (fa echoAbstraction) respondWithError(err error, errorMsg string, statusCode int) {
+	fa.ctx.String(statusCode, errorMsg)
 }
 
 func (fa echoAbstraction) getHTTPrequest() *http.Request {
 	return fa.ctx.Request()
 }
 
-func (fa echoAbstraction) respondWithInvoice(headers map[string]string, statusCode int, body []byte) error {
+func (fa echoAbstraction) respondWithInvoice(headers map[string]string, statusCode int, body []byte) {
 	for k, v := range headers {
 		fa.ctx.Response().Header().Set(k, v)
 	}
-	return fa.ctx.String(statusCode, string(body))
+	fa.ctx.String(statusCode, string(body))
 }
 
 func (fa echoAbstraction) next() error {

--- a/wall/echo.go
+++ b/wall/echo.go
@@ -37,11 +37,7 @@ func (fa echoAbstraction) getPreimageFromHeader() string {
 }
 
 func (fa echoAbstraction) respondWithError(err error, errorMsg string, statusCode int) error {
-	return &echo.HTTPError{
-		Code:     statusCode,
-		Message:  errorMsg,
-		Internal: err,
-	}
+	return fa.ctx.String(statusCode, errorMsg)
 }
 
 func (fa echoAbstraction) getHTTPrequest() *http.Request {
@@ -52,13 +48,7 @@ func (fa echoAbstraction) respondWithInvoice(headers map[string]string, statusCo
 	for k, v := range headers {
 		fa.ctx.Response().Header().Set(k, v)
 	}
-	fa.ctx.Response().Status = statusCode
-	// The actual invoice goes into the body
-	fa.ctx.Response().Write(body)
-	return &echo.HTTPError{
-		Code:    statusCode,
-		Message: string(body),
-	}
+	return fa.ctx.String(statusCode, string(body))
 }
 
 func (fa echoAbstraction) next() error {

--- a/wall/gin.go
+++ b/wall/gin.go
@@ -25,17 +25,16 @@ func (fa ginAbstraction) getPreimageFromHeader() string {
 	return fa.ctx.GetHeader("x-preimage")
 }
 
-func (fa ginAbstraction) respondWithError(err error, errorMsg string, statusCode int) error {
+func (fa ginAbstraction) respondWithError(err error, errorMsg string, statusCode int) {
 	http.Error(fa.ctx.Writer, errorMsg, statusCode)
 	fa.ctx.Abort()
-	return nil
 }
 
 func (fa ginAbstraction) getHTTPrequest() *http.Request {
 	return fa.ctx.Request
 }
 
-func (fa ginAbstraction) respondWithInvoice(headers map[string]string, statusCode int, body []byte) error {
+func (fa ginAbstraction) respondWithInvoice(headers map[string]string, statusCode int, body []byte) {
 	for k, v := range headers {
 		fa.ctx.Header(k, v)
 	}
@@ -43,7 +42,6 @@ func (fa ginAbstraction) respondWithInvoice(headers map[string]string, statusCod
 	fa.ctx.Writer.Write(body)
 
 	fa.ctx.Abort()
-	return nil
 }
 
 func (fa ginAbstraction) next() error {

--- a/wall/gin.go
+++ b/wall/gin.go
@@ -1,63 +1,52 @@
 package wall
 
 import (
-	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/philippgille/ln-paywall/ln"
 )
 
 // NewGinMiddleware returns a Gin middleware in the form of a gin.HandlerFunc.
 func NewGinMiddleware(invoiceOptions InvoiceOptions, lnClient LNclient, storageClient StorageClient) gin.HandlerFunc {
 	invoiceOptions = assignDefaultValues(invoiceOptions)
 	return func(ctx *gin.Context) {
-		// Check if the request contains a header with the preimage that we need to check if the requester paid
-		preimageHex := ctx.GetHeader("x-preimage")
-		if preimageHex == "" {
-			// Generate the invoice
-			invoice, err := lnClient.GenerateInvoice(invoiceOptions.Price, invoiceOptions.Memo)
-			if err != nil {
-				errorMsg := fmt.Sprintf("Couldn't generate invoice: %+v", err)
-				log.Println(errorMsg)
-				http.Error(ctx.Writer, errorMsg, http.StatusInternalServerError)
-				ctx.Abort()
-			} else {
-				// Cache the invoice metadata
-				metadata := invoiceMetaData{
-					ImplDepID: invoice.ImplDepID,
-					Method:    ctx.Request.Method,
-					Path:      ctx.Request.URL.Path,
-				}
-				storageClient.Set(invoice.PaymentHash, metadata)
-
-				stdOutLogger.Printf("Sending invoice in response: %v", invoice.PaymentRequest)
-				ctx.Header("Content-Type", "application/vnd.lightning.bolt11")
-				ctx.Status(http.StatusPaymentRequired)
-				// The actual invoice goes into the body
-				ctx.Writer.Write([]byte(invoice.PaymentRequest))
-				ctx.Abort()
-			}
-		} else {
-			// Check if the provided preimage belongs to a settled API payment invoice and that it wasn't already used. Also store used preimages.
-			invalidPreimageMsg, err := handlePreimage(ctx.Request, storageClient, lnClient)
-			if err != nil {
-				errorMsg := fmt.Sprintf("An error occurred during checking the preimage: %+v", err)
-				log.Printf("%v\n", errorMsg)
-				http.Error(ctx.Writer, errorMsg, http.StatusInternalServerError)
-				ctx.Abort()
-			} else if invalidPreimageMsg != "" {
-				log.Printf("%v: %v\n", invalidPreimageMsg, preimageHex)
-				http.Error(ctx.Writer, invalidPreimageMsg, http.StatusBadRequest)
-				ctx.Abort()
-			} else {
-				preimageHash, err := ln.HashPreimage(preimageHex)
-				if err == nil {
-					stdOutLogger.Printf("The provided preimage is valid. Continuing to the next handler. Preimage hash: %v\n", preimageHash)
-				}
-				ctx.Next()
-			}
+		fa := ginAbstraction{
+			ctx: ctx,
 		}
+		commonHandler(fa, invoiceOptions, lnClient, storageClient)
 	}
+}
+
+type ginAbstraction struct {
+	ctx *gin.Context
+}
+
+func (fa ginAbstraction) getPreimageFromHeader() string {
+	return fa.ctx.GetHeader("x-preimage")
+}
+
+func (fa ginAbstraction) respondWithError(err error, errorMsg string, statusCode int) error {
+	http.Error(fa.ctx.Writer, errorMsg, statusCode)
+	fa.ctx.Abort()
+	return nil
+}
+
+func (fa ginAbstraction) getHTTPrequest() *http.Request {
+	return fa.ctx.Request
+}
+
+func (fa ginAbstraction) respondWithInvoice(headers map[string]string, statusCode int, body []byte) error {
+	for k, v := range headers {
+		fa.ctx.Header(k, v)
+	}
+	fa.ctx.Status(statusCode)
+	fa.ctx.Writer.Write(body)
+
+	fa.ctx.Abort()
+	return nil
+}
+
+func (fa ginAbstraction) next() error {
+	fa.ctx.Next()
+	return nil
 }

--- a/wall/middleware.go
+++ b/wall/middleware.go
@@ -2,6 +2,7 @@ package wall
 
 import (
 	"encoding/hex"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -75,6 +76,58 @@ type invoiceMetaData struct {
 	Method    string
 	Path      string
 	Used      bool
+}
+
+type frameworkAbstraction interface {
+	getPreimageFromHeader() string
+	respondWithError(string, int)
+	getHTTPrequest() *http.Request
+	sendResponse(map[string]string, int, []byte)
+	next()
+}
+
+func commonHandler(fa frameworkAbstraction, invoiceOptions InvoiceOptions, lnClient LNclient, storageClient StorageClient) {
+	// Check if the request contains a header with the preimage that we need to check if the requester paid
+	preimageHex := fa.getPreimageFromHeader()
+	if preimageHex == "" {
+		// Generate the invoice
+		invoice, err := lnClient.GenerateInvoice(invoiceOptions.Price, invoiceOptions.Memo)
+		if err != nil {
+			errorMsg := fmt.Sprintf("Couldn't generate invoice: %+v", err)
+			log.Println(errorMsg)
+			fa.respondWithError(errorMsg, http.StatusInternalServerError)
+		} else {
+			// Cache the invoice metadata
+			metadata := invoiceMetaData{
+				ImplDepID: invoice.ImplDepID,
+				Method:    fa.getHTTPrequest().Method,
+				Path:      fa.getHTTPrequest().URL.Path,
+			}
+			storageClient.Set(invoice.PaymentHash, metadata)
+
+			stdOutLogger.Printf("Sending invoice in response: %v", invoice.PaymentRequest)
+			headers := make(map[string]string)
+			headers["Content-Type"] = "application/vnd.lightning.bolt11"
+			fa.sendResponse(headers, http.StatusPaymentRequired, []byte(invoice.PaymentRequest))
+		}
+	} else {
+		// Check if the provided preimage belongs to a settled API payment invoice and that it wasn't already used. Also store used preimages.
+		invalidPreimageMsg, err := handlePreimage(fa.getHTTPrequest(), storageClient, lnClient)
+		if err != nil {
+			errorMsg := fmt.Sprintf("An error occurred during checking the preimage: %+v", err)
+			log.Printf("%v\n", errorMsg)
+			fa.respondWithError(errorMsg, http.StatusInternalServerError)
+		} else if invalidPreimageMsg != "" {
+			log.Printf("%v: %v\n", invalidPreimageMsg, preimageHex)
+			fa.respondWithError(invalidPreimageMsg, http.StatusBadRequest)
+		} else {
+			preimageHash, err := ln.HashPreimage(preimageHex)
+			if err == nil {
+				stdOutLogger.Printf("The provided preimage is valid. Continuing to the next handler. Preimage hash: %v\n", preimageHash)
+			}
+			fa.next()
+		}
+	}
 }
 
 // handlePreimage does the following:

--- a/wall/middleware.go
+++ b/wall/middleware.go
@@ -80,9 +80,9 @@ type invoiceMetaData struct {
 
 type frameworkAbstraction interface {
 	getPreimageFromHeader() string
-	respondWithError(error, string, int) error
+	respondWithError(error, string, int)
 	getHTTPrequest() *http.Request
-	respondWithInvoice(map[string]string, int, []byte) error
+	respondWithInvoice(map[string]string, int, []byte)
 	next() error
 }
 
@@ -95,10 +95,7 @@ func commonHandler(fa frameworkAbstraction, invoiceOptions InvoiceOptions, lnCli
 		if err != nil {
 			errorMsg := fmt.Sprintf("Couldn't generate invoice: %+v", err)
 			log.Println(errorMsg)
-			err := fa.respondWithError(err, errorMsg, http.StatusInternalServerError)
-			if err != nil {
-				return err
-			}
+			fa.respondWithError(err, errorMsg, http.StatusInternalServerError)
 		} else {
 			// Cache the invoice metadata
 			metadata := invoiceMetaData{
@@ -111,10 +108,7 @@ func commonHandler(fa frameworkAbstraction, invoiceOptions InvoiceOptions, lnCli
 			stdOutLogger.Printf("Sending invoice in response: %v", invoice.PaymentRequest)
 			headers := make(map[string]string)
 			headers["Content-Type"] = "application/vnd.lightning.bolt11"
-			err := fa.respondWithInvoice(headers, http.StatusPaymentRequired, []byte(invoice.PaymentRequest))
-			if err != nil {
-				return err
-			}
+			fa.respondWithInvoice(headers, http.StatusPaymentRequired, []byte(invoice.PaymentRequest))
 		}
 	} else {
 		// Check if the provided preimage belongs to a settled API payment invoice and that it wasn't already used. Also store used preimages.
@@ -122,16 +116,10 @@ func commonHandler(fa frameworkAbstraction, invoiceOptions InvoiceOptions, lnCli
 		if err != nil {
 			errorMsg := fmt.Sprintf("An error occurred during checking the preimage: %+v", err)
 			log.Printf("%v\n", errorMsg)
-			err := fa.respondWithError(err, errorMsg, http.StatusInternalServerError)
-			if err != nil {
-				return err
-			}
+			fa.respondWithError(err, errorMsg, http.StatusInternalServerError)
 		} else if invalidPreimageMsg != "" {
 			log.Printf("%v: %v\n", invalidPreimageMsg, preimageHex)
-			err := fa.respondWithError(nil, invalidPreimageMsg, http.StatusBadRequest)
-			if err != nil {
-				return err
-			}
+			fa.respondWithError(nil, invalidPreimageMsg, http.StatusBadRequest)
 		} else {
 			preimageHash, err := ln.HashPreimage(preimageHex)
 			if err == nil {

--- a/wall/stdlib.go
+++ b/wall/stdlib.go
@@ -40,16 +40,15 @@ func (fa stdlibHTTP) getPreimageFromHeader() string {
 	return fa.r.Header.Get("x-preimage")
 }
 
-func (fa stdlibHTTP) respondWithError(err error, errorMsg string, statusCode int) error {
+func (fa stdlibHTTP) respondWithError(err error, errorMsg string, statusCode int) {
 	http.Error(fa.w, errorMsg, statusCode)
-	return nil
 }
 
 func (fa stdlibHTTP) getHTTPrequest() *http.Request {
 	return fa.r
 }
 
-func (fa stdlibHTTP) respondWithInvoice(headers map[string]string, statusCode int, body []byte) error {
+func (fa stdlibHTTP) respondWithInvoice(headers map[string]string, statusCode int, body []byte) {
 	// Note: w.Header().Set(...) must be called before w.WriteHeader(...)!
 	for k, v := range headers {
 		fa.w.Header().Set(k, v)
@@ -58,8 +57,6 @@ func (fa stdlibHTTP) respondWithInvoice(headers map[string]string, statusCode in
 	fa.w.WriteHeader(statusCode)
 	// The actual invoice goes into the body
 	fa.w.Write(body)
-
-	return nil
 }
 
 func (fa stdlibHTTP) next() error {

--- a/wall/stdlib.go
+++ b/wall/stdlib.go
@@ -40,15 +40,16 @@ func (fa stdlibHTTP) getPreimageFromHeader() string {
 	return fa.r.Header.Get("x-preimage")
 }
 
-func (fa stdlibHTTP) respondWithError(errorMsg string, statusCode int) {
+func (fa stdlibHTTP) respondWithError(err error, errorMsg string, statusCode int) error {
 	http.Error(fa.w, errorMsg, statusCode)
+	return nil
 }
 
 func (fa stdlibHTTP) getHTTPrequest() *http.Request {
 	return fa.r
 }
 
-func (fa stdlibHTTP) sendResponse(headers map[string]string, statusCode int, body []byte) {
+func (fa stdlibHTTP) respondWithInvoice(headers map[string]string, statusCode int, body []byte) error {
 	// Note: w.Header().Set(...) must be called before w.WriteHeader(...)!
 	for k, v := range headers {
 		fa.w.Header().Set(k, v)
@@ -57,8 +58,11 @@ func (fa stdlibHTTP) sendResponse(headers map[string]string, statusCode int, bod
 	fa.w.WriteHeader(statusCode)
 	// The actual invoice goes into the body
 	fa.w.Write(body)
+
+	return nil
 }
 
-func (fa stdlibHTTP) next() {
+func (fa stdlibHTTP) next() error {
 	fa.nextHandler.ServeHTTP(fa.w, fa.r)
+	return nil
 }

--- a/wall/stdlib.go
+++ b/wall/stdlib.go
@@ -1,72 +1,64 @@
 package wall
 
 import (
-	"fmt"
-	"log"
 	"net/http"
-
-	"github.com/philippgille/ln-paywall/ln"
 )
 
 // NewHandlerFuncMiddleware returns a function which you can use within an http.HandlerFunc chain.
 func NewHandlerFuncMiddleware(invoiceOptions InvoiceOptions, lnClient LNclient, storageClient StorageClient) func(http.HandlerFunc) http.HandlerFunc {
 	return func(next http.HandlerFunc) http.HandlerFunc {
-		return createHandlerFunc(invoiceOptions, lnClient, storageClient, next, "HandlerFunc")
+		return createHandlerFunc(invoiceOptions, lnClient, storageClient, next)
 	}
 }
 
 // NewHandlerMiddleware returns a function which you can use within an http.Handler chain.
 func NewHandlerMiddleware(invoiceOptions InvoiceOptions, lnClient LNclient, storageClient StorageClient) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(createHandlerFunc(invoiceOptions, lnClient, storageClient, next.ServeHTTP, "Handler"))
+		return http.HandlerFunc(createHandlerFunc(invoiceOptions, lnClient, storageClient, next.ServeHTTP))
 	}
 }
 
-func createHandlerFunc(invoiceOptions InvoiceOptions, lnClient LNclient, storageClient StorageClient, next http.HandlerFunc, handlingType string) func(w http.ResponseWriter, r *http.Request) {
+func createHandlerFunc(invoiceOptions InvoiceOptions, lnClient LNclient, storageClient StorageClient, next http.HandlerFunc) func(w http.ResponseWriter, r *http.Request) {
 	invoiceOptions = assignDefaultValues(invoiceOptions)
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Check if the request contains a header with the preimage that we need to check if the requester paid
-		preimageHex := r.Header.Get("x-preimage")
-		if preimageHex == "" {
-			// Generate the invoice
-			invoice, err := lnClient.GenerateInvoice(invoiceOptions.Price, invoiceOptions.Memo)
-			if err != nil {
-				errorMsg := fmt.Sprintf("Couldn't generate invoice: %+v", err)
-				log.Println(errorMsg)
-				http.Error(w, errorMsg, http.StatusInternalServerError)
-			} else {
-				// Cache the invoice metadata
-				metadata := invoiceMetaData{
-					ImplDepID: invoice.ImplDepID,
-					Method:    r.Method,
-					Path:      r.URL.Path,
-				}
-				storageClient.Set(invoice.PaymentHash, metadata)
-
-				stdOutLogger.Printf("Sending invoice in response: %v", invoice.PaymentRequest)
-				// Note: w.Header().Set(...) must be called before w.WriteHeader(...)!
-				w.Header().Set("Content-Type", "application/vnd.lightning.bolt11")
-				w.WriteHeader(http.StatusPaymentRequired)
-				// The actual invoice goes into the body
-				w.Write([]byte(invoice.PaymentRequest))
-			}
-		} else {
-			// Check if the provided preimage belongs to a settled API payment invoice and that it wasn't already used. Also store used preimages.
-			invalidPreimageMsg, err := handlePreimage(r, storageClient, lnClient)
-			if err != nil {
-				errorMsg := fmt.Sprintf("An error occurred during checking the preimage: %+v", err)
-				log.Printf("%v\n", errorMsg)
-				http.Error(w, errorMsg, http.StatusInternalServerError)
-			} else if invalidPreimageMsg != "" {
-				log.Printf("%v: %v\n", invalidPreimageMsg, preimageHex)
-				http.Error(w, invalidPreimageMsg, http.StatusBadRequest)
-			} else {
-				preimageHash, err := ln.HashPreimage(preimageHex)
-				if err == nil {
-					stdOutLogger.Printf("The provided preimage is valid. Continuing to the next %v. Preimage hash: %v\n", handlingType, preimageHash)
-				}
-				next.ServeHTTP(w, r)
-			}
+		fa := stdlibHTTP{
+			w:           w,
+			r:           r,
+			nextHandler: next,
 		}
+		commonHandler(fa, invoiceOptions, lnClient, storageClient)
 	}
+}
+
+type stdlibHTTP struct {
+	w           http.ResponseWriter
+	r           *http.Request
+	nextHandler http.HandlerFunc
+}
+
+func (fa stdlibHTTP) getPreimageFromHeader() string {
+	return fa.r.Header.Get("x-preimage")
+}
+
+func (fa stdlibHTTP) respondWithError(errorMsg string, statusCode int) {
+	http.Error(fa.w, errorMsg, statusCode)
+}
+
+func (fa stdlibHTTP) getHTTPrequest() *http.Request {
+	return fa.r
+}
+
+func (fa stdlibHTTP) sendResponse(headers map[string]string, statusCode int, body []byte) {
+	// Note: w.Header().Set(...) must be called before w.WriteHeader(...)!
+	for k, v := range headers {
+		fa.w.Header().Set(k, v)
+	}
+	// Status code
+	fa.w.WriteHeader(statusCode)
+	// The actual invoice goes into the body
+	fa.w.Write(body)
+}
+
+func (fa stdlibHTTP) next() {
+	fa.nextHandler.ServeHTTP(fa.w, fa.r)
 }


### PR DESCRIPTION
Currently the middleware factory functions contain a lot of duplicated code. There should be only one web framework-independent function that contains the main middleware logic, and then web framework-specific implementations that handle the details of the used web frameworks.

This PR contains that, including a fix for the middleware for Echo.